### PR TITLE
必要ないtestファイル、coffeeファイル、helperファイルの削除

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,10 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.generators do |g|
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
#What
config.generators do |g|
をconfig/application.rbに書く
#Why
不要なファイルを生成しないようにするため